### PR TITLE
Use `#![no_std]` + `alloc`

### DIFF
--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cwextab"
-version = "1.0.3"
+version = "1.0.4"
 edition = "2021"
 authors = ["Amber Brault <celestialamber1@gmail.com>"]
 license = "MIT OR Apache-2.0"
@@ -8,6 +8,7 @@ repository = "https://github.com/Celestialamber/cwextab"
 readme = "../README.md"
 description = "CodeWarrior Exception Table decoder"
 rust-version = "1.58"
+categories = ["no-std"]
 
 [dependencies]
-thiserror = "1.0.64"
+thiserror = { version = "2.0", default-features = false }

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -1,3 +1,9 @@
+#![no_std]
+extern crate alloc;
+
+use alloc::string::String;
+use alloc::{format, vec};
+use alloc::vec::Vec;
 use thiserror::Error;
 
 mod mem_utils;
@@ -263,7 +269,6 @@ impl ExceptionAction {
         let offset: u32 = match self.get_dtor_address_value_offset() {
             Some(val) => val,
             None => {
-                println!("Error: tried to get dtor address value offset for table which doesn't have it");
                 return None;
             }
         };
@@ -801,12 +806,12 @@ impl ExceptionTableData {
                 //If the action references a dtor, print it out using the name array
                 if has_dtor_ref {
                     if func_index >= func_names.len() {
-                        println!("Error: Invalid function array index");
-                        return None;
+                        line += "Error: Invalid function array index\n";
+                    } else {
+                        let func_name = func_names[func_index].as_str();
+                        line += format!("Dtor: \"{func_name}\"\n").as_str();
+                        func_index += 1;
                     }
-                    let func_name = func_names[func_index].as_str();
-                    line += format!("Dtor: \"{func_name}\"\n").as_str();
-                    func_index += 1;
                 }
 
                 if action.has_end_bit {


### PR DESCRIPTION
This makes the crate work in `#![no_std]` + `alloc` environments by default.

I had to adjust the couple of stray `println!`s, let me know if you'd like these cases handled differently.